### PR TITLE
Implement minimal CaseEngine logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
-# courthouse
+# Courthouse
 
-This repository was initialized by Terragon.
+Prototype for an LLM-powered courtroom simulator with a Three.js interface.
+
+## Structure
+
+- `client/` – static assets for rendering a minimal 3D courtroom
+- `src/agents/` – engine for coordinating LLM participants
+- `docs/` – architectural design notes
+
+Run the static page with any HTTP server, e.g.:
+
+```bash
+npx http-server client
+```
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the Node.js test suite:
+
+```bash
+npm test
+```

--- a/client/courtroom.js
+++ b/client/courtroom.js
@@ -1,0 +1,69 @@
+import * as THREE from 'three';
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+const renderer = new THREE.WebGLRenderer({
+  canvas: document.getElementById('courtroom'),
+  antialias: true
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+// lighting
+const light = new THREE.AmbientLight(0xffffff, 0.8);
+scene.add(light);
+
+// floor
+const floor = new THREE.Mesh(
+  new THREE.PlaneGeometry(20, 20),
+  new THREE.MeshPhongMaterial({ color: 0x8b4513 })
+);
+floor.rotation.x = -Math.PI / 2;
+scene.add(floor);
+
+// judge bench
+const bench = new THREE.Mesh(
+  new THREE.BoxGeometry(4, 2, 1),
+  new THREE.MeshPhongMaterial({ color: 0x654321 })
+);
+bench.position.set(0, 1, -5);
+scene.add(bench);
+
+// witness stand
+const witness = new THREE.Mesh(
+  new THREE.BoxGeometry(1.5, 1.5, 1),
+  new THREE.MeshPhongMaterial({ color: 0x8b4513 })
+);
+witness.position.set(3, 0.75, -2);
+scene.add(witness);
+
+function createTable(x) {
+  const table = new THREE.Mesh(
+    new THREE.BoxGeometry(3, 1, 1.5),
+    new THREE.MeshPhongMaterial({ color: 0xa0522d })
+  );
+  table.position.set(x, 0.5, 0);
+  return table;
+}
+
+scene.add(createTable(-3)); // defense
+scene.add(createTable(3)); // prosecution
+
+camera.position.set(0, 5, 10);
+camera.lookAt(0, 0, -5);
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+animate();
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mock Courtroom</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <canvas id="courtroom"></canvas>
+  <script type="module" src="courtroom.js"></script>
+</body>
+</html>

--- a/client/styles.css
+++ b/client/styles.css
@@ -1,0 +1,8 @@
+body {
+  margin: 0;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,65 @@
+# LLM-Powered Mock Courtroom
+
+This document outlines the architecture for an end-to-end courtroom simulator
+that combines a Three.js 3D scene with large language models (LLMs) acting as
+participants in a mock trial.
+
+## Goals
+
+- Visualize a simple courtroom in the browser
+- Allow the player to assume any role (judge, counsel, defendant, juror, etc.)
+  or observe the simulation
+- Support multiple LLM providers (OpenAI, Anthropic, Grok, Groq, Ollama,
+  LMStudio, OpenRouter, etc.)
+- Scaffold case creation, evidence exchange, and trial procedure
+- Support abbreviated or full simulations, including pre-trial phases
+
+## Technologies
+
+- **Three.js** for rendering a minimal 3D courtroom scene
+- **CaseEngine** (see `src/agents/caseEngine.js`) for managing roles and
+  interactions with LLMs
+- **Microsoft TinyTroupe** for early prototyping of multi-agent conversations
+
+## Core Components
+
+### 3D Courtroom
+
+The `client` folder contains a static page that renders a courtroom with a
+bench, witness stand, and counsel tables. This scene can later be expanded with
+animated participants and UI overlays for procedural actions.
+
+### Case Engine
+
+The `CaseEngine` class manages:
+
+1. **Case Generation** – Use an LLM to create the facts of the case and
+   establish required evidence. Images and videos can be requested as JSON
+   descriptors for external generation.
+2. **Role Assignment** – Produce biographies and motivations for all actors:
+   judge, prosecutor, defense, defendant, witnesses, and jurors (6–12, default
+   6).
+3. **Trial Orchestration** – Step through openings, witness examinations with
+   objections, sidebars, and closing arguments. Final verdict may be produced
+   by judge or jury agents.
+4. **Persistence** – Store API keys securely on the client; case state is held
+   locally or in a sandboxed backend.
+
+`CaseEngine` accepts configuration options such as desired `jurySize` (default
+6) and whether to `includeWitnesses`, allowing simulations to skip witness
+examinations altogether.
+
+### Simulation Controls
+
+- Toggle witness participation and jury size
+- Choose which roles the player controls versus AI agents
+- Select level of detail (abbreviated vs. full procedure)
+- Hooks for pre-trial motions and discovery exchange
+
+### Future Enhancements
+
+- Timeline and personal schedules for agents to perform research and planning
+- Support for uploading evidence (PDF, image, video) with automatic text
+  extraction for LLM review
+- Integration of TinyTroupe agents to model discussions among counsel and jury
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "courthouse",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "courthouse",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "three": "^0.179.1"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.179.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.179.1.tgz",
+      "integrity": "sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "courthouse",
+  "version": "1.0.0",
+  "description": "This repository was initialized by Terragon.",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "three": "^0.179.1"
+  }
+}

--- a/src/agents/caseEngine.js
+++ b/src/agents/caseEngine.js
@@ -1,0 +1,62 @@
+/**
+ * Minimal engine for orchestrating a mock LLM‑driven courtroom.
+ * The class is written to accommodate OpenAI‑compatible providers such as
+ * OpenAI, Anthropic, Grok, Groq, Ollama, LMStudio, or OpenRouter. Network
+ * calls are not implemented here; instead the methods return deterministic
+ * structures so the rest of the application can be exercised and tested.
+ */
+
+export class CaseEngine {
+  constructor(config = {}) {
+    this.config = {
+      jurySize: 6,
+      includeWitnesses: true,
+      ...config,
+    }; // { provider: 'openai', apiKey: '...' }
+  }
+
+  /**
+   * Build a procedural case using an LLM.
+   * @param {string} prompt - description of the dispute
+   * @returns {Promise<object>} case outline and generated evidence requests
+   */
+  async buildCase(prompt) {
+    return {
+      summary: `Mock case for: ${prompt}`,
+      // include a trivial piece of evidence so the trial can render a verdict
+      evidence: [{ id: 1, description: 'Sample evidence' }],
+      witnesses: [{ id: 1, name: 'Alex Witness' }],
+    };
+  }
+
+  /**
+   * Assign personas for judge, counsel, jury and witnesses
+   */
+  async assignRoles(caseData) {
+    const jury = Array.from({ length: this.config.jurySize }, (_, i) => ({
+      id: i + 1,
+      role: 'juror',
+    }));
+
+    const baseRoles = {
+      judge: { name: 'Judge Judy', role: 'judge' },
+      prosecutor: { name: 'Pat Prosecutor', role: 'prosecutor' },
+      defense: { name: 'Dan Defense', role: 'defense' },
+      defendant: { name: 'Daisy Defendant', role: 'defendant' },
+      jury,
+    };
+
+    const witnesses = this.config.includeWitnesses ? caseData.witnesses : [];
+
+    return { ...caseData, ...baseRoles, witnesses };
+  }
+
+  /**
+   * Run the trial, managing openings, evidence presentation, and verdict
+   */
+  async runTrial(caseData) {
+    // extremely naive verdict: presence of evidence implies guilt
+    const verdict = caseData.evidence.length > 0 ? 'guilty' : 'not guilty';
+    return { ...caseData, verdict };
+  }
+}

--- a/test/caseEngine.test.js
+++ b/test/caseEngine.test.js
@@ -1,0 +1,28 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { CaseEngine } from '../src/agents/caseEngine.js';
+
+test('buildCase returns mock case structure', async () => {
+  const engine = new CaseEngine();
+  const result = await engine.buildCase('dispute');
+  assert.equal(result.summary, 'Mock case for: dispute');
+  assert.ok(Array.isArray(result.evidence));
+  assert.equal(result.witnesses.length, 1);
+});
+
+test('assignRoles respects config', async () => {
+  const engine = new CaseEngine({ jurySize: 8, includeWitnesses: false });
+  const caseData = await engine.buildCase('dispute');
+  const roles = await engine.assignRoles(caseData);
+  assert.equal(roles.jury.length, 8);
+  assert.equal(roles.witnesses.length, 0);
+  assert.ok(roles.judge);
+});
+
+test('runTrial produces verdict based on evidence', async () => {
+  const engine = new CaseEngine();
+  const caseData = await engine.buildCase('dispute');
+  const roles = await engine.assignRoles(caseData);
+  const result = await engine.runTrial(roles);
+  assert.equal(result.verdict, 'guilty');
+});


### PR DESCRIPTION
## Summary
- replace placeholder CaseEngine with deterministic case generation, role assignment, and verdict logic
- update tests and documentation to reflect engine behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a513cb50508332a43a680c073ac0f2